### PR TITLE
Add support channel & "Fix" magic values

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ and hit enter
 ⚠️ The gamemode config used by Pinejinx supports the re-nice feature for some additional performance, to use it you must create a gamemode group using `sudo groupadd gamemode` and throw your user in using `sudo usermod -a -G gamemode $USER`<br>
 ⚠️ Regarding laptop users with NVIDIA GPUs, Ryujinx will have to merge the EGL pull request before Pinejinx can support you<br>
 
-Please come at Ryujinx's Discord server if you face any issues. We'll gladly support you at the #linux-master-race channel
+Please come at Ryujinx's Discord server if you face any issues. We'll gladly support you at the #linux-support channel

--- a/Ryujinx.xml
+++ b/Ryujinx.xml
@@ -5,7 +5,7 @@
         <acronym>NRO</acronym>
         <icon name="Ryujinx"/>
         <glob pattern="*.nro"/>
-        <magic><match value="NRO" type="string" offset="16"/></magic>
+        <magic><match value="NRO0" type="string" offset="16"/></magic>
     </mime-type>
 
     <mime-type type="application/x-nx-nso">
@@ -13,7 +13,7 @@
         <acronym>NSO</acronym>
         <icon name="Ryujinx"/>
         <glob pattern="*.nso"/>
-        <magic><match value="NSO" type="string" offset="0"/></magic>
+        <magic><match value="NSO0" type="string" offset="0"/></magic>
     </mime-type>
     
     <mime-type type="application/x-nx-nsp">
@@ -21,7 +21,7 @@
         <acronym>NSP</acronym>
         <icon name="Ryujinx"/>
         <glob pattern="*.nsp"/>
-        <magic><match value="PFS" type="string" offset="0"/></magic>
+        <magic><match value="PFS0" type="string" offset="0"/></magic>
     </mime-type>
 
     <mime-type type="application/x-nx-xci">
@@ -29,5 +29,6 @@
         <acronym>XCI</acronym>
         <icon name="Ryujinx"/>
         <glob pattern="*.xci"/>
+        <magic><match value="HEAD" type="string" offset="4352"/></magic>
     </mime-type>
 </mime-info>

--- a/pinejinx.sh
+++ b/pinejinx.sh
@@ -19,7 +19,7 @@ getoptions() {
 	read -p "Do you want PineJinx to setup an alias for ryujinx? [y/N]: " alias
 }
 makealias() {
-    ryualias='alias ryujinx="'$arg' COMPlus_EnableAlternateStackCheck=1 GDK_BACKEND=x11 /home/'${USER}'/.local/share/Ryujinx/Ryujinx"'
+    ryualias='alias ryujinx="'$arg' DOTNET_EnableAlternateStackCheck=1 GDK_BACKEND=x11 /home/'${USER}'/.local/share/Ryujinx/Ryujinx"'
     if [ -z "${SHELL##*zsh*}" ]; then
         printf "Detected shell: ZSH\n"
         FILE="/home/${USER}/.zshrc"


### PR DESCRIPTION
We recently added a new support channel for Linux, so users should be redirected there instead.

~~Since we merged https://github.com/Ryujinx/Ryujinx/pull/3516, we can remove the `GDK_BACKEND=x11` env var now.~~

I also added the magic value for XCI and edited the others to include the complete magic value.